### PR TITLE
Specify using python 3

### DIFF
--- a/elevation_mapping_cupy/CMakeLists.txt
+++ b/elevation_mapping_cupy/CMakeLists.txt
@@ -2,8 +2,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(elevation_mapping_cupy)
 
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
+find_package(PythonLibs 3 REQUIRED)
 
 if(PYTHONLIBS_FOUND)
   message(STATUS "Using Python Libraries at: " ${PYTHON_LIBRARIES})


### PR DESCRIPTION
This removes the need to compile with `-DPYTHON_EXECUTABLE=$(which python3)`, which should also resolve possible issues if you mix your workspace with packages using python 2.7 (under melodic / ubuntu 18.04 / Jetson)