### PR TITLE
merge 3 loops around edges into 1

### DIFF
--- a/plane_segmentation/convex_plane_decomposition/include/convex_plane_decomposition/ConvexRegionGrowing.h
+++ b/plane_segmentation/convex_plane_decomposition/include/convex_plane_decomposition/ConvexRegionGrowing.h
@@ -15,10 +15,6 @@ CgalPolygon2d growConvexPolygonInsideShape(const CgalPolygon2d& parentShape, Cga
 CgalPolygon2d growConvexPolygonInsideShape(const CgalPolygonWithHoles2d& parentShape, CgalPoint2d center, int numberOfVertices,
                                            double growthFactor);
 
-template <typename T>
-bool pointCanBeMoved(const CgalPolygon2d& growthShape, int i, const CgalPoint2d& candidatePoint, CgalCircle2d& freeSphere,
-                     const T& parentShape);
-
 void updateMean(CgalPoint2d& mean, const CgalPoint2d& oldValue, const CgalPoint2d& updatedValue, int N);
 
 }  // namespace convex_plane_decomposition


### PR DESCRIPTION
In the worst case there were 3 loops around the polygon required. These can be merged to one. It reduces the runtime variance a bit by removing this worst-case scenario