### PR TITLE
Removed typo include

### DIFF
--- a/plane_segmentation/convex_plane_decomposition/include/convex_plane_decomposition/PlaneDecompositionPipeline.h
+++ b/plane_segmentation/convex_plane_decomposition/include/convex_plane_decomposition/PlaneDecompositionPipeline.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <grid_map_msgs/GridMap.h>
-
 #include "convex_plane_decomposition/GridMapPreprocessing.h"
 #include "convex_plane_decomposition/PlanarRegion.h"
 #include "convex_plane_decomposition/Postprocessing.h"


### PR DESCRIPTION
Removed include of grid_map_msgs from in PlaneDecompositionPipeline.h, likely a typo