### PR TITLE
Change how pybind is included in cpp files

### DIFF
--- a/elevation_mapping_cupy/include/elevation_mapping_cupy/elevation_mapping_ros.hpp
+++ b/elevation_mapping_cupy/include/elevation_mapping_cupy/elevation_mapping_ros.hpp
@@ -13,7 +13,7 @@
 #include <Eigen/Dense>
 
 // Pybind
-#include <pybind11_catkin/pybind11/embed.h>  // everything needed for embedding
+#include <pybind11/embed.h>  // everything needed for embedding
 
 // ROS
 #include <geometry_msgs/PolygonStamped.h>

--- a/elevation_mapping_cupy/include/elevation_mapping_cupy/elevation_mapping_wrapper.hpp
+++ b/elevation_mapping_cupy/include/elevation_mapping_cupy/elevation_mapping_wrapper.hpp
@@ -12,7 +12,7 @@
 #include <Eigen/Dense>
 
 // Pybind
-#include <pybind11_catkin/pybind11/embed.h>  // everything needed for embedding
+#include <pybind11/embed.h>  // everything needed for embedding
 
 // ROS
 #include <geometry_msgs/PoseWithCovarianceStamped.h>

--- a/elevation_mapping_cupy/src/elevation_mapping_node.cpp
+++ b/elevation_mapping_cupy/src/elevation_mapping_node.cpp
@@ -4,7 +4,7 @@
 //
 
 // Pybind
-#include <pybind11_catkin/pybind11/embed.h>  // everything needed for embedding
+#include <pybind11/embed.h>  // everything needed for embedding
 
 // ROS
 #include <ros/ros.h>

--- a/elevation_mapping_cupy/src/elevation_mapping_ros.cpp
+++ b/elevation_mapping_cupy/src/elevation_mapping_ros.cpp
@@ -6,7 +6,7 @@
 #include "elevation_mapping_cupy/elevation_mapping_ros.hpp"
 
 // Pybind
-#include <pybind11_catkin/pybind11/eigen.h>
+#include <pybind11/eigen.h>
 
 // ROS
 #include <geometry_msgs/Point32.h>

--- a/elevation_mapping_cupy/src/elevation_mapping_wrapper.cpp
+++ b/elevation_mapping_cupy/src/elevation_mapping_wrapper.cpp
@@ -6,7 +6,7 @@
 #include "elevation_mapping_cupy/elevation_mapping_wrapper.hpp"
 
 // Pybind
-#include <pybind11_catkin/pybind11/eigen.h>
+#include <pybind11/eigen.h>
 
 // PCL
 #include <pcl/common/projection_matrix.h>


### PR DESCRIPTION
Hi all,

I've been testing the elevation_mapping_cupy package in different platforms and I have observed different behaviors depending on how `pybind11_catkin` is installed/compiled. In particular, I have tested:

1. pybind11_catkin from apt: `sudo apt install ros-noetic-pybind11-catkin`
2. Manual catkin compilation of `pybind11_catkin`, since I have a fork that updates pybind to 2.9.2 (the one from the binaries is 2.5.0): https://github.com/mmattamala/pybind11_catkin

When I follow the instructions with pybind from apt, it works as expected. However, with the second case I get the following error:
```sh
Errors     << elevation_mapping_cupy:make /root/catkin_ws/logs/elevation_mapping_cupy/build.make.007.log             
In file included from /root/catkin_ws/src/elevation_mapping_cupy/elevation_maHi @mktk1117 

I've been testing the elevation_mapping_cupy package in different platforms and I have observed different behaviors depending on how `pybind11_catkin` is installed/compiled. In particular, I have tested:

1. pybind11_catkin from apt: `sudo apt install ros-noetic-pybind11-catkin`
2. Manual catkin compilation of `pybind11_catkin`, since I have a fork that updates pybind to 2.9.2 (the one from the binaries is 2.5.0): https://github.com/mmattamala/pybind11_catkin

When I follow the instructions with pybind from apt, it works as expected. However, with the second case I get the following error:
```sh
Errors     << elevation_mapping_cupy:make /root/catkin_ws/logs/elevation_mapping_cupy/build.make.007.log             
In file included from /root/catkin_ws/src/elevation_mapping_cupy/elevation_mapping_cupy/src/elevation_mapping_wrapper.cpp:6:
/root/catkin_ws/src/elevation_mapping_cupy/elevation_mapping_cupy/include/elevation_mapping_cupy/elevation_mapping_wrapper.hpp:15:10: fatal error: pybind11_catkin/pybind11/embed.h: No such file or directory
   15 | #include <pybind11_catkin/pybind11/embed.h>  // everything needed for embedding
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from /root/catkin_ws/src/elevation_mapping_cupy/elevation_mapping_cupy/src/elevation_mapping_ros.cpp:6:
/root/catkin_ws/src/elevation_mapping_cupy/elevation_mapping_cupy/include/elevation_mapping_cupy/elevation_mapping_ros.hpp:16:10: fatal error: pybind11_catkin/pybind11/embed.h: No such file or directory
   16 | #include <pybind11_catkin/pybind11/embed.h>  // everything needed for embedding
```

I noticed that pybind is included in all the cpp files using  the `pybind11_catkin` prefix, for example: `#include <pybind11_catkin/pybind11/embed.h>`. However, if instead we just use `#include <pybind11/embed.h>` it works for both the binaries and the custom compilation of pybind.

As a summary:

|                                   | apt pybind | compiled pybind |
|------------------------------------------------|------------------------|-----------------|
| #include pybind11_catkin/pybind11 |       :heavy_check_mark:  |          :x:        |
| #include pybind11                           |         :heavy_check_mark:   |        :heavy_check_mark:         |