### PR TITLE
Fix plane decomposition launch and run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 [Documentation](https://leggedrobotics.github.io/elevation_mapping_cupy/)
 
-
 ## Overview
 
-The Elevaton Mapping CuPy software package represents an advancement in robotic navigation and locomotion. 
+The Elevaton Mapping CuPy software package represents an advancement in robotic navigation and locomotion.
 Integrating with the Robot Operating System (ROS) and utilizing GPU acceleration, this framework enhances point cloud registration and ray casting,
 crucial for efficient and accurate robotic movement, particularly in legged robots.
 ![screenshot](docs/media/main_repo.png)
@@ -38,6 +37,7 @@ layers of the map. Finally the map can be post-processed with various custom plu
 external components (e.g. line detection).
 
 ## Citing
+
 If you use the Elevation Mapping CuPy, please cite the following paper:
 Elevation Mapping for Locomotion and Navigation using GPU
 
@@ -71,7 +71,7 @@ Gian Erni, Jonas Frey, Takahiro Miki, Matias Mattamala, Marco Hutter
 }
 ```
 
-## Quick instructions to run:
+## Quick instructions to run
 
 ### Installation
 
@@ -87,19 +87,19 @@ Then install dependencies.
 You can also use docker which already install all dependencies.
 When you run the script it should pull the image.
 
-
 ```zsh
 cd docker
 ./run.sh
 ```
 
-You can also build locally by running `build.sh`.
+You can also build locally by running `build.sh`, but in this case change `IMAGE_NAME` in `run.sh` to `elevation_mapping_cupy:latest`.
 
 For more information, check [Document](https://leggedrobotics.github.io/elevation_mapping_cupy/getting_started/installation.html)
 
 ### Build package
 
 Inside docker container.
+
 ```zsh
 cd $HOME/catkin_ws
 catkin build elevation_mapping_cupy
@@ -107,7 +107,8 @@ catkin build convex_plane_decomposition_ros  # If you want to use plane segmenta
 catkin build semantic_sensor  # If you want to use semantic sensors
 ```
 
-### Run turtlebot example.
+### Run turtlebot example
+
 ![Elevation map examples](docs/media/turtlebot.png)
 
 ```bash

--- a/elevation_mapping_cupy/launch/turtlesim_plane_decomposition_example.launch
+++ b/elevation_mapping_cupy/launch/turtlesim_plane_decomposition_example.launch
@@ -3,7 +3,7 @@
 <launch>
 
     <!-- Launch elevation mapping turtle sim. -->
-    <include file="$(find elevation_mapping_cupy)/launch/turtlesim_example.launch">
+    <include file="$(find elevation_mapping_cupy)/launch/turtlesim_simple_example.launch">
         <arg name="rviz_config" value="$(find elevation_mapping_cupy)/rviz/turtle_segmentation_example.rviz"/>
     </include>
 


### PR DESCRIPTION
I just started to explore this repo and found 2 typos I had to fix to be able to follow tutorial examples with turtlebot:

- build.sh creates image with name `elevation_mapping_cupy:latest`, while run.sh assumes this image named `mktk1117/elevation_mapping_cupy:latest`
- `turtlesim_plane_decomposition_example.launch` includes `turtlesim_example.launch`, when there is no such launch. I assumed that `turtlesim_simple_example.launch` should be included instead and then everything launched fine.