### PR TITLE
Networkx installation error fix

### DIFF
--- a/docker/Dockerfile.x64
+++ b/docker/Dockerfile.x64
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install PyTorch
-RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+RUN pip3 install networkx==3.0 torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
 

--- a/docker/Dockerfile.x64
+++ b/docker/Dockerfile.x64
@@ -16,9 +16,9 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install PyTorch
-RUN pip3 install networkx==3.0 torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
+RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 
 # Install other Python packages
 RUN pip3 install cupy-cuda11x scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ simple-parsing
 scikit-image==0.19
 matplotlib
 catkin-tools
+networkx==3.0
 # cupy
 
 ###### Requirements with Version Specifiers ######`


### PR DESCRIPTION
https://github.com/leggedrobotics/elevation_mapping_cupy/issues/87 Newest version of Networkx only available for Python >3.9.