### PR TITLE
Fixed an issue when there's 'rgb' layer in the grid map. 

### DIFF
--- a/elevation_mapping_cupy/src/elevation_mapping_ros.cpp
+++ b/elevation_mapping_cupy/src/elevation_mapping_ros.cpp
@@ -500,7 +500,7 @@ void ElevationMappingNode::updatePose(const ros::TimerEvent&) {
 
 void ElevationMappingNode::publishAsPointCloud(const grid_map::GridMap& map) const {
   sensor_msgs::PointCloud2 msg;
-  grid_map::GridMapRosConverter::toPointCloud(map, "elevation", msg);
+  grid_map::GridMapRosConverter::toPointCloud(map, {"elevation"}, "elevation", msg);
   pointPub_.publish(msg);
 }
 


### PR DESCRIPTION
The gridmap library was somehow using rgb and color as some hardcoded layer names inside this toPointCloud function and causing a crash.

Now I'm just using elevation layer for the point cloud publishing.