### PR TITLE
Fix Dilation Filter Kernel

### DIFF
--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/kernels/custom_kernels.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/kernels/custom_kernels.py
@@ -431,8 +431,8 @@ def dilation_filter_kernel(width, height, dilation_size):
                         int idx = get_relative_map_idx(i, dx, dy, 0);
                         if (!is_inside(idx)) {continue;}
                         U valid = mask[idx];
-                        if(valid > 0.5 && dx + dy < distance) {
-                            distance = dx + dy;
+                        if(valid > 0.5 && abs(dx) + abs(dy) < distance) {
+                            distance = abs(dx) + abs(dy);
                             near_value = map[idx];
                         }
                     }


### PR DESCRIPTION
Fix the distance calculation for the `dilation_filter_kernel` in `elevation_mapping_cupy/script/elevation_mapping_cupy/kernels/custom_kernels.py`. Use `abs(dx) + abs(dy)` instead of `dx + dy` since `dx` and `dy` can be negative.