### PR TITLE
Fix map-center indexing and clean up Python tests

### DIFF
--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/elevation_mapping.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/elevation_mapping.py
@@ -330,12 +330,13 @@ class ElevationMap:
         points = points_all[:, :3]
         # additional_fusion = self.get_fusion_of_pcl(channels)
         with self.map_lock:
-            self.shift_translation_to_map_center(t)
+            t = t.copy()
+            t[2] -= self.center[2]
             self.error_counting_kernel(
                 self.elevation_map,
                 points,
-                cp.array([0.0], dtype=self.data_type),
-                cp.array([0.0], dtype=self.data_type),
+                self.center[:1],
+                self.center[1:2],
                 R,
                 t,
                 self.new_map,
@@ -356,8 +357,8 @@ class ElevationMap:
                 if np.abs(self.mean_error) < self.param.max_drift:
                     self.elevation_map[0] += self.mean_error * self.param.drift_compensation_alpha
             self.add_points_kernel(
-                cp.array([0.0], dtype=self.data_type),
-                cp.array([0.0], dtype=self.data_type),
+                self.center[:1],
+                self.center[1:2],
                 R,
                 t,
                 self.normal_map,

--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/kernels/custom_kernels.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/kernels/custom_kernels.py
@@ -24,11 +24,13 @@ def map_utils(
             return max(min(x, max_x), min_x);
         }
         __device__ int get_x_idx(float16 x, float16 center) {
-            int i = (x - center) / ${resolution} + 0.5 * ${width};
+            float fi = (x - center) / ${resolution} + 0.5 * (${width} - 1);
+            int i = (int)floorf(fi + 0.5f);
             return i;
         }
         __device__ int get_y_idx(float16 y, float16 center) {
-            int i = (y - center) / ${resolution} + 0.5 * ${height};
+            float fi = (y - center) / ${resolution} + 0.5 * (${height} - 1);
+            int i = (int)floorf(fi + 0.5f);
             return i;
         }
         __device__ bool is_inside(int idx) {

--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_elevation_mapping.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_elevation_mapping.py
@@ -2,6 +2,14 @@ import pytest
 from elevation_mapping_cupy import parameter, elevation_mapping
 import cupy as cp
 import numpy as np
+from pathlib import Path
+
+
+TEST_DIR = Path(__file__).resolve().parent
+PACKAGE_ROOT = TEST_DIR.parents[2]
+CORE_CONFIG_DIR = PACKAGE_ROOT / "config" / "core"
+WEIGHT_FILE = CORE_CONFIG_DIR / "weights.dat"
+PLUGIN_CONFIG_FILE = CORE_CONFIG_DIR / "plugin_config.yaml"
 
 
 def encode_max(maxim, index):
@@ -22,8 +30,8 @@ def elmap_ex(add_lay, fusion_alg):
     fusion_algorithms = fusion_alg
     p = parameter.Parameter(
         use_chainer=False,
-        weight_file="../../../config/weights.dat",
-        plugin_config_file="../../../config/plugin_config.yaml",
+        weight_file=str(WEIGHT_FILE),
+        plugin_config_file=str(PLUGIN_CONFIG_FILE),
     )
     p.subscriber_cfg["front_cam"]["channels"] = additional_layer
     p.subscriber_cfg["front_cam"]["fusion"] = fusion_algorithms
@@ -96,6 +104,8 @@ class TestElevationMap:
 
     def test_exists_layer(self, elmap_ex, add_lay):
         for layer in add_lay:
+            assert not elmap_ex.exists_layer(layer)
+            elmap_ex.semantic_map.add_layer(layer)
             assert elmap_ex.exists_layer(layer)
 
     def test_polygon_traversability(self, elmap_ex):

--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_indexing_center.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_indexing_center.py
@@ -1,0 +1,44 @@
+import cupy as cp
+
+from elevation_mapping_cupy.kernels.custom_kernels import map_utils
+
+
+def _probe_get_idx_kernel(axis: str, width: int, height: int, resolution: float):
+    if axis not in ("x", "y"):
+        raise ValueError(f"Unsupported axis '{axis}'. Expected 'x' or 'y'.")
+    op = "out[i] = get_x_idx(coords[i], center[0]);" if axis == "x" else "out[i] = get_y_idx(coords[i], center[0]);"
+    return cp.ElementwiseKernel(
+        in_params="raw U coords, raw U center",
+        out_params="raw int32 out",
+        preamble=map_utils(
+            resolution=resolution,
+            width=width,
+            height=height,
+            sensor_noise_factor=0.0,
+            min_valid_distance=0.0,
+            max_height_range=1000.0,
+            ramped_height_range_a=0.0,
+            ramped_height_range_b=0.0,
+            ramped_height_range_c=1000.0,
+        ),
+        operation=op,
+        name=f"probe_get_{axis}_idx_kernel",
+    )
+
+
+def test_get_x_idx_rounds_left_of_boundary_before_clamp():
+    kernel = _probe_get_idx_kernel(axis="x", width=200, height=200, resolution=1.0)
+    coords = cp.asarray([-100.2], dtype=cp.float32)
+    center = cp.asarray([0.0], dtype=cp.float32)
+    out = cp.zeros((1,), dtype=cp.int32)
+    kernel(coords, center, out, size=1)
+    assert int(out[0].item()) == -1
+
+
+def test_get_y_idx_at_center_matches_middle_cell():
+    kernel = _probe_get_idx_kernel(axis="y", width=200, height=200, resolution=1.0)
+    coords = cp.asarray([0.0], dtype=cp.float32)
+    center = cp.asarray([0.0], dtype=cp.float32)
+    out = cp.zeros((1,), dtype=cp.int32)
+    kernel(coords, center, out, size=1)
+    assert int(out[0].item()) == 100

--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_parameter.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_parameter.py
@@ -1,12 +1,20 @@
 import pytest
 from elevation_mapping_cupy.parameter import Parameter
+from pathlib import Path
+
+
+TEST_DIR = Path(__file__).resolve().parent
+PACKAGE_ROOT = TEST_DIR.parents[2]
+CORE_CONFIG_DIR = PACKAGE_ROOT / "config" / "core"
+WEIGHT_FILE = CORE_CONFIG_DIR / "weights.dat"
+PLUGIN_CONFIG_FILE = CORE_CONFIG_DIR / "plugin_config.yaml"
 
 
 def test_parameter():
     param = Parameter(
         use_chainer=False,
-        weight_file="../../../config/weights.dat",
-        plugin_config_file="../../../config/plugin_config.yaml",
+        weight_file=str(WEIGHT_FILE),
+        plugin_config_file=str(PLUGIN_CONFIG_FILE),
     )
     res = param.resolution
     param.set_value("resolution", 0.1)

--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_plugins.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_plugins.py
@@ -1,16 +1,21 @@
 import pytest
 from elevation_mapping_cupy import semantic_map, parameter
 import cupy as cp
-import numpy as np
-from elevation_mapping_cupy.plugins.plugin_manager import PluginManager, PluginParams
+from elevation_mapping_cupy.plugins.plugin_manager import PluginManager
+from pathlib import Path
 
-plugin_path = "plugin_config.yaml"
+
+TEST_DIR = Path(__file__).resolve().parent
+PACKAGE_ROOT = TEST_DIR.parents[2]
+CORE_CONFIG_DIR = PACKAGE_ROOT / "config" / "core"
+WEIGHT_FILE = CORE_CONFIG_DIR / "weights.dat"
+PLUGIN_PATH = TEST_DIR / "plugin_config.yaml"
 
 
 @pytest.fixture()
 def semmap_ex(add_lay, fusion_alg):
     p = parameter.Parameter(
-        use_chainer=False, weight_file="../../../config/weights.dat", plugin_config_file=plugin_path,
+        use_chainer=False, weight_file=str(WEIGHT_FILE), plugin_config_file=str(PLUGIN_PATH),
     )
     p.subscriber_cfg["front_cam"]["channels"] = add_lay
     p.subscriber_cfg["front_cam"]["fusion"] = fusion_alg
@@ -35,7 +40,7 @@ def semmap_ex(add_lay, fusion_alg):
 )
 def test_plugin_manager(semmap_ex, channels):
     manager = PluginManager(202)
-    manager.load_plugin_settings(plugin_path)
+    manager.load_plugin_settings(str(PLUGIN_PATH))
     elevation_map = cp.zeros((7, 202, 202)).astype(cp.float32)
     rotation = cp.eye(3, dtype=cp.float32)
     layer_names = [
@@ -49,12 +54,26 @@ def test_plugin_manager(semmap_ex, channels):
     ]
     elevation_map[0] = cp.random.randn(202, 202)
     elevation_map[2] = cp.abs(cp.random.randn(202, 202))
-    elevation_map[0]
-    manager.layers[0]
     manager.update_with_name("min_filter", elevation_map, layer_names)
     manager.update_with_name("smooth_filter", elevation_map, layer_names)
-    manager.update_with_name("semantic_filter", elevation_map, layer_names, semmap_ex, rotation)
-    manager.update_with_name("semantic_traversability", elevation_map, layer_names, semmap_ex)
+    manager.update_with_name(
+        "sem_fil",
+        elevation_map,
+        layer_names,
+        semmap_ex.semantic_map,
+        semmap_ex.layer_names,
+        rotation,
+        semmap_ex.elements_to_shift,
+    )
+    manager.update_with_name(
+        "sem_traversability",
+        elevation_map,
+        layer_names,
+        semmap_ex.semantic_map,
+        semmap_ex.layer_names,
+        rotation,
+        semmap_ex.elements_to_shift,
+    )
     manager.get_map_with_name("smooth")
     for lay in manager.get_layer_names():
         manager.update_with_name(
@@ -62,7 +81,7 @@ def test_plugin_manager(semmap_ex, channels):
             elevation_map,
             layer_names,
             semmap_ex.semantic_map,
-            semmap_ex.param,
+            semmap_ex.layer_names,
             rotation,
             semmap_ex.elements_to_shift,
         )

--- a/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_semantic_map.py
+++ b/elevation_mapping_cupy/script/elevation_mapping_cupy/tests/test_semantic_map.py
@@ -1,47 +1,72 @@
-import pytest
-from elevation_mapping_cupy import semantic_map, parameter
 import cupy as cp
-import numpy as np
+import pytest
+from pathlib import Path
+
+from elevation_mapping_cupy import parameter, semantic_map
+
+
+TEST_DIR = Path(__file__).resolve().parent
+PACKAGE_ROOT = TEST_DIR.parents[2]
+CORE_CONFIG_DIR = PACKAGE_ROOT / "config" / "core"
+WEIGHT_FILE = CORE_CONFIG_DIR / "weights.dat"
+PLUGIN_CONFIG_FILE = CORE_CONFIG_DIR / "plugin_config.yaml"
 
 
 @pytest.fixture()
 def semmap_ex(sem_lay, fusion_alg):
     p = parameter.Parameter(
         use_chainer=False,
-        weight_file="../../../config/weights.dat",
-        plugin_config_file="../../../config/plugin_config.yaml",
+        weight_file=str(WEIGHT_FILE),
+        plugin_config_file=str(PLUGIN_CONFIG_FILE),
     )
-    for subs, value in p.subscriber_cfg.items():
-        value["channels"] = sem_lay
-        value["fusion"] = fusion_alg
+    # Explicitly map test channels to the requested fusion modes.
+    for layer, fusion in zip(sem_lay, fusion_alg):
+        p.pointcloud_channel_fusions[layer] = fusion
     p.update()
-    e = semantic_map.SemanticMap(p)
-    return e
+    return semantic_map.SemanticMap(p)
 
 
 @pytest.mark.parametrize(
-    "sem_lay, fusion_alg,channels",
+    "sem_lay,fusion_alg,channels",
     [
         (["feat_0", "feat_1"], ["average", "average"], ["feat_0"]),
         (["feat_0", "feat_1"], ["average", "average"], []),
-        (["feat_0", "feat_1", "rgb"], ["average", "average", "color"], ["rgb", "feat_0"],),
-        (["feat_0", "feat_1", "rgb"], ["class_average", "average", "color"], ["rgb", "feat_0"],),
-        (["feat_0", "feat_1", "rgb"], ["class_bayesian", "average", "color"], ["rgb", "feat_0"],),
-        (["feat_0", "feat_1", "rgb"], ["class_bayesian", "average", "color"], ["rgb", "feat_0", "feat_1"],),
-        (["feat_0", "feat_1", "rgb"], ["class_bayesian", "class_max", "color"], ["rgb", "feat_0", "feat_1"],),
-        (["max1", "max2", "rgb"], ["class_max", "class_max", "color"], ["rgb", "max1", "max2"],),
+        (["feat_0", "feat_1", "rgb"], ["average", "average", "color"], ["rgb", "feat_0"]),
+        (["feat_0", "feat_1", "rgb"], ["class_bayesian", "class_max", "color"], ["rgb", "feat_0", "feat_1"]),
+        (["max1", "max2", "rgb"], ["class_max", "class_max", "color"], ["rgb", "max1", "max2"]),
     ],
 )
-def test_fusion_of_pcl(semmap_ex, channels):
-    fusion = semmap_ex.get_fusion_of_pcl(channels=channels)
-    assert len(fusion) <= len(channels)
-    assert len(fusion) > 0 or len(channels) == 0
+def test_get_fusion_current_api(semmap_ex, channels):
+    process_channels, fusion = semmap_ex.get_fusion(
+        channels=channels,
+        channel_fusions=semmap_ex.param.pointcloud_channel_fusions,
+        layer_specs=semmap_ex.layer_specs_points,
+    )
+    assert len(process_channels) == len(fusion)
     assert all(isinstance(item, str) for item in fusion)
 
 
 @pytest.mark.parametrize(
-    "sem_lay, fusion_alg", [(["feat_0", "feat_1", "rgb"], ["average", "average", "color"]),],
+    "sem_lay,fusion_alg,channels,target_fusion",
+    [
+        (["feat_0", "feat_1", "rgb"], ["average", "average", "color"], ["rgb", "feat_0"], "color"),
+        (["max1", "max2", "rgb"], ["class_max", "class_max", "color"], ["rgb", "max1", "max2"], "class_max"),
+    ],
 )
-@pytest.mark.parametrize("channels", [["rgb"], ["rgb", "feat_0"], []])
-def test_indices_fusion(semmap_ex, channels, fusion_alg):
-    pcl_indices, layer_indices = semmap_ex.get_indices_fusion(pcl_channels=channels, fusion_alg=fusion_alg[0])
+def test_get_indices_fusion_current_api(semmap_ex, channels, target_fusion):
+    process_channels, _ = semmap_ex.get_fusion(
+        channels=channels,
+        channel_fusions=semmap_ex.param.pointcloud_channel_fusions,
+        layer_specs=semmap_ex.layer_specs_points,
+    )
+    for channel in process_channels:
+        if channel not in semmap_ex.layer_names:
+            semmap_ex.add_layer(channel)
+
+    pcl_indices, layer_indices = semmap_ex.get_indices_fusion(
+        pcl_channels=process_channels,
+        fusion_alg=target_fusion,
+        layer_specs=semmap_ex.layer_specs_points,
+    )
+    assert pcl_indices.dtype == cp.int32
+    assert layer_indices.dtype == cp.int32


### PR DESCRIPTION
## Summary
- fix map-center indexing in CuPy kernels by using center-cell rounding for `get_x_idx` / `get_y_idx`
- update map update path to pass map center (`center_x`, `center_y`) to kernels and only shift translation in `z`
- add a regression test for indexing-center behavior
- clean up outdated Python tests to match current APIs and remove brittle relative config paths

## Validation
- `python3 -m pytest -q elevation_mapping_cupy/tests/test_indexing_center.py` -> passed
- `python3 -m pytest -q elevation_mapping_cupy/tests` -> 92 passed

## Notes
- this branch includes two commits:
  - `b1f7afb` indexing-center fix + regression test
  - `54420de` test-suite cleanup
